### PR TITLE
Improves the Signal class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,30 @@
 
 .DS_Store
-node_modules/
-coverage/
-dist/
+
+# Logs
+logs
+*.log
 *.tmp
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+coverage
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@micurs/rp-lib",
+    "version": "1.0.0",
+    "module": "dist/index.js",
+    "main": "dist/index.js",
+    "typings": "dist/index.d.ts"
+}

--- a/lib/tests/operators/concat-map.test.ts
+++ b/lib/tests/operators/concat-map.test.ts
@@ -1,8 +1,8 @@
 /// <reference lib="deno.ns" />
 
 import { expect } from "jsr:@std/expect";
-import { Subject, concatMap } from "../src/index.ts";
-import { defer } from "./utils.ts";
+import { Subject, concatMap } from "../../src/index.ts";
+import { defer } from "../utils.ts";
 
 Deno.test("concatMap should map values to inner observables and emit them sequentially", async () => {
   const source$ = new Subject<number>();

--- a/lib/tests/operators/concat.test.ts
+++ b/lib/tests/operators/concat.test.ts
@@ -1,7 +1,7 @@
 /// <reference lib="deno.ns" />
 
 import { expect } from "jsr:@std/expect";
-import { Subject, concat } from "../src/index.ts";
+import { Subject, concat } from "../../src/index.ts";
 
 
 Deno.test("should emit all values from the first observable before the second", () => {

--- a/lib/tests/operators/flat-map.test.ts
+++ b/lib/tests/operators/flat-map.test.ts
@@ -9,8 +9,8 @@ import {
   fromPromise,
   interval,
   map,
-} from "../src/index.ts";
-import { defer } from "./utils.ts";
+} from "../../src/index.ts";
+import { defer } from "../utils.ts";
 
 Deno.test("Operator flatMap flattens the result of a mapped observable", async () => {
   // A generator that emits 3 values after 5, 10 and 15 ms

--- a/lib/tests/operators/switch-map.test.ts
+++ b/lib/tests/operators/switch-map.test.ts
@@ -1,8 +1,8 @@
 /// <reference lib="deno.ns" />
 import { assertSpyCalls, spy } from "jsr:@std/testing/mock";
-import { from, switchMap, Subject } from "../src/index.ts";
+import { from, switchMap, Subject } from "../../src/index.ts";
 import { expect } from "jsr:@std/expect";
-import { defer } from "./utils.ts";
+import { defer } from "../utils.ts";
 
 Deno.test("switchMap should map and switch inner observables correctly", () => {
   const numbers$ = from(1, 2, 3);

--- a/lib/tests/operators/trans-operators-1.test.ts
+++ b/lib/tests/operators/trans-operators-1.test.ts
@@ -2,7 +2,7 @@
 
 import { assertSpyCallArg, assertSpyCalls, spy } from "jsr:@std/testing/mock";
 
-import { from, map, Subject, tap } from "../src/index.ts";
+import { from, map, Subject, tap } from "../../src/index.ts";
 
 Deno.test("tap operator - call the provided function with each value", () => {
   const obs$ = from(1, 2, 3);

--- a/lib/tests/signals/signal-basic.test.ts
+++ b/lib/tests/signals/signal-basic.test.ts
@@ -62,4 +62,17 @@ Deno.test('Two computed signals emit their computed values when their dependent 
   Signal.effect(effect);
   source1.value = 200;
   assertSpyCalls(effect, 2);
+});
+
+
+Deno.test('Two computed signals emit their computed values when their dependent signal changes', () => {
+  const source1 = new Signal(0);
+  const computed1 = Signal.computed(() => source1.value! + 100);
+  const computed2 = Signal.computed(() => computed1.value! + 100);
+  const effect = spy(() => {
+    console.log('computed2 signals changed to =>', computed2.value);
+  });
+  Signal.effect(effect);
+  source1.value = 1000;
+  assertSpyCalls(effect, 2);
 })

--- a/lib/tests/signals/signal-basic.test.ts
+++ b/lib/tests/signals/signal-basic.test.ts
@@ -1,6 +1,7 @@
 /// <reference lib="deno.ns" />
 
 import { assertSpyCalls, spy } from "jsr:@std/testing/mock";
+import { expect } from "jsr:@std/expect";
 
 import { Signal } from "../../../lib/src/signals/signal.ts";
 
@@ -17,7 +18,9 @@ Deno.test("Emitting a value on a signal calls the effect function", () => {
   const signal = new Signal(100);
   const effect = spy(() => { console.log("spy1 called", signal.value) });
   Signal.effect(effect);
+  expect(signal.value).toBe(100);
   signal.value = 200;
+  expect(signal.value).toBe(200);
   assertSpyCalls(effect, 2);
 });
 
@@ -27,15 +30,18 @@ Deno.test("Disabling an effect function stops it from being called", () => {
   const disableEffect = Signal.effect(effect);
   disableEffect();
   signal.value = 200;
+  expect(signal.value).toBe(200);
   assertSpyCalls(effect, 1);
 });
 
 Deno.test('A computed signal effect function is called when a dependent signal changes', () => {
   const signal1 = new Signal(100);
   const computedSignal = Signal.computed(() => signal1.value ? signal1.value.toFixed(2) : '');
+  expect(computedSignal.value).toBe('100.00');
   const effect = spy(() => { console.log('computed signal changed to =>', computedSignal.value) });
   Signal.effect(effect);
   signal1.value = 200;
+  expect(computedSignal.value).toBe('200.00');
   assertSpyCalls(effect, 2);
 });
 
@@ -47,7 +53,9 @@ Deno.test('Two computed signals emit their computed values when their dependent 
     console.log('computed signals changed to =>', computed1.value, computed2.value);
   });
   Signal.effect(effect);
-  source.value = 200;
+  source.value = 101;
+  expect(computed1.value).toBe(false);
+  expect(computed2.value).toBe(true);
   assertSpyCalls(effect, 3);
 });
 
@@ -61,6 +69,7 @@ Deno.test('Two computed signals emit their computed values when their dependent 
   });
   Signal.effect(effect);
   source1.value = 200;
+  expect(computed.value).toBe(500);
   assertSpyCalls(effect, 2);
 });
 
@@ -74,5 +83,7 @@ Deno.test('Two computed signals emit their computed values when their dependent 
   });
   Signal.effect(effect);
   source1.value = 1000;
+  expect(computed1.value).toBe(1100);
+  expect(computed2.value).toBe(1200);
   assertSpyCalls(effect, 2);
 })

--- a/lib/tests/signals/signal-basic.test.ts
+++ b/lib/tests/signals/signal-basic.test.ts
@@ -1,0 +1,65 @@
+/// <reference lib="deno.ns" />
+
+import { assertSpyCalls, spy } from "jsr:@std/testing/mock";
+
+import { Signal } from "../../../lib/src/signals/signal.ts";
+
+
+Deno.test("Creating an effect function with a signal", () => {
+  const signal = new Signal(100);
+  const effect = spy(() => { console.log("spy1 called", signal.value) });
+  Signal.effect(effect);
+  assertSpyCalls(effect, 1);
+});
+
+
+Deno.test("Emitting a value on a signal calls the effect function", () => {
+  const signal = new Signal(100);
+  const effect = spy(() => { console.log("spy1 called", signal.value) });
+  Signal.effect(effect);
+  signal.value = 200;
+  assertSpyCalls(effect, 2);
+});
+
+Deno.test("Disabling an effect function stops it from being called", () => {
+  const signal = new Signal(100);
+  const effect = spy(() => { console.log("spy1 called", signal.value) });
+  const disableEffect = Signal.effect(effect);
+  disableEffect();
+  signal.value = 200;
+  assertSpyCalls(effect, 1);
+});
+
+Deno.test('A computed signal effect function is called when a dependent signal changes', () => {
+  const signal1 = new Signal(100);
+  const computedSignal = Signal.computed(() => signal1.value ? signal1.value.toFixed(2) : '');
+  const effect = spy(() => { console.log('computed signal changed to =>', computedSignal.value) });
+  Signal.effect(effect);
+  signal1.value = 200;
+  assertSpyCalls(effect, 2);
+});
+
+Deno.test('Two computed signals emit their computed values when their dependent signal changes', () => {
+  const source = new Signal(100);
+  const computed1 = Signal.computed(() => source.value && source.value % 2 === 0);
+  const computed2 = Signal.computed(() => source.value && source.value % 2 !== 0);
+  const effect = spy(() => {
+    console.log('computed signals changed to =>', computed1.value, computed2.value);
+  });
+  Signal.effect(effect);
+  source.value = 200;
+  assertSpyCalls(effect, 3);
+});
+
+
+Deno.test('Two computed signals emit their computed values when their dependent signal changes', () => {
+  const source1 = new Signal(100);
+  const source2 = new Signal(300);
+  const computed = Signal.computed(() => source1.value! + source2.value!);
+  const effect = spy(() => {
+    console.log('computed signals changed to =>', computed.value);
+  });
+  Signal.effect(effect);
+  source1.value = 200;
+  assertSpyCalls(effect, 2);
+})


### PR DESCRIPTION
## Summary

This PR improves the Signal class. Now the `Signal.computed()` function creates a signal that will
execute its effect function every time one of the dependent signal (mentioned in the function) changes value.

Add some initial tests for Signal.

```
ok | 59 passed | 0 failed (1s)

--------------------------------------------------------
File                               | Branch % | Line % |
--------------------------------------------------------
 src/compose-pipe.ts               |    100.0 |  100.0 |
 src/creation-operators.ts         |     76.9 |   92.3 |
 src/index.ts                      |    100.0 |  100.0 |
 src/observable.ts                 |    100.0 |  100.0 |
 src/signals/signal.ts             |     66.7 |   90.7 |
 src/trans-operators/concat-map.ts |    100.0 |  100.0 |
 src/trans-operators/concat.ts     |    100.0 |  100.0 |
 src/trans-operators/flat-map.ts   |    100.0 |   90.0 |
 src/trans-operators/map.ts        |    100.0 |  100.0 |
 src/trans-operators/merge.ts      |    100.0 |  100.0 |
 src/trans-operators/switch-map.ts |    100.0 |  100.0 |
 src/trans-operators/tap.ts        |    100.0 |  100.0 |
 tests/utils.ts                    |    100.0 |  100.0 |
--------------------------------------------------------
 All files                         |     92.3 |   96.2 |
--------------------------------------------------------
```

## Notes

The computed() implementation relies on a new static Map in the Signal class that collect the 
dependent observables for each given effect function. 