### PR TITLE
Micurs/throttle

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -38,4 +38,4 @@ jobs:
         run: deno lint
 
       - name: Run tests
-        run: deno test -A
+        run: deno run test

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "tasks": {
     "bundle": "deno task --config lib/deno.json bundle && deno task --config react-lib/deno.json bundle",

--- a/lib/src/filter-operators/debounce.ts
+++ b/lib/src/filter-operators/debounce.ts
@@ -1,5 +1,3 @@
-// <reference lib="deno.ns" />
-
 import type { Observable, Operator } from '../index.ts';
 import { Subject } from '../index.ts';
 

--- a/lib/src/filter-operators/throttle.ts
+++ b/lib/src/filter-operators/throttle.ts
@@ -1,0 +1,33 @@
+import type { Observable, Operator } from '../index.ts';
+import { Subject } from '../index.ts';
+
+/**
+ * The throttle operator creates a new observable that only emits
+ * a value from the source observable if they are received a given time apart.
+ * If a value is received before the time has passed, it is ignored.
+ * @param time - the time the values should be apart
+ * @returns the new observable that emits the values with the given time apart
+ */
+export const throttle = <T>(time: number): Operator<T, T> => {
+  return <T>(source$: Observable<T>): Observable<T> => {
+    const result$ = new Subject<T>();
+    let lastEmissionTime: number | undefined = undefined;
+    source$.subscribe({
+      next: (val: T) => {
+        if (lastEmissionTime === undefined) {
+          result$.emit(val);
+          lastEmissionTime = Date.now();
+          return;
+        }
+        const deltaTime = Date.now() - lastEmissionTime;
+        if (deltaTime >= time) {
+          result$.emit(val);
+          lastEmissionTime = Date.now();
+        }
+      },
+      error: (err: Error) => result$.error(err),
+      complete: () => result$.complete(),
+    });
+    return result$;
+  };
+};

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -10,6 +10,7 @@ export * from './trans-operators/switch-map.ts';
 export * from './trans-operators/concat-map.ts';
 export * from './filter-operators/filter.ts';
 export * from './filter-operators/debounce.ts';
+export * from './filter-operators/throttle.ts';
 export * from './compose-pipe.ts';
 export * from './signals/signal.ts';
 

--- a/lib/tests/filter-operators/throttle.test.ts
+++ b/lib/tests/filter-operators/throttle.test.ts
@@ -1,0 +1,17 @@
+import { expect } from 'jsr:@std/expect';
+import { fromArray, throttle } from '../../src/index.ts';
+
+Deno.test('throttle should emit only one value if the original observable emits all the values in the given time', async () => {
+  const source$ = fromArray([1, 2, 3, 4, 5]);
+  const result$ = throttle<number>(10)(source$);
+  const res: Array<number> = [];
+
+  result$.subscribe({
+    next: (value: number) => {
+      res.push(value);
+    },
+    complete: () => {
+      expect(res).toEqual([1]);
+    },
+  });
+});

--- a/lib/tests/filter-operators/throttle.test.ts
+++ b/lib/tests/filter-operators/throttle.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'jsr:@std/expect';
 import { fromArray, throttle } from '../../src/index.ts';
 
-Deno.test('throttle should emit only one value if the original observable emits all the values in the given time', async () => {
+Deno.test('throttle should emit only one value if the original observable emits all the values in the given time', () => {
   const source$ = fromArray([1, 2, 3, 4, 5]);
   const result$ = throttle<number>(10)(source$);
   const res: Array<number> = [];


### PR DESCRIPTION
## Summary

Adding `throttle` to the filter operators.


## Tests

```
--------------------------------------------------------
 src/compose-pipe.ts               |    100.0 |  100.0 |
 src/creation-operators.ts         |     75.0 |   92.1 |
 src/filter-operators/debounce.ts  |    100.0 |   82.1 |
 src/filter-operators/filter.ts    |    100.0 |   94.7 |
 src/filter-operators/throttle.ts  |     66.7 |   79.2 |
 src/index.ts                      |    100.0 |  100.0 |
 src/observable.ts                 |    100.0 |  100.0 |
 src/signals/signal.ts             |     66.7 |   89.3 |
 src/trans-operators/concat-map.ts |    100.0 |  100.0 |
 src/trans-operators/concat.ts     |    100.0 |  100.0 |
 src/trans-operators/flat-map.ts   |    100.0 |   90.0 |
 src/trans-operators/map.ts        |    100.0 |  100.0 |
 src/trans-operators/merge.ts      |    100.0 |  100.0 |
 src/trans-operators/switch-map.ts |    100.0 |  100.0 |
 src/trans-operators/tap.ts        |    100.0 |  100.0 |
 tests/utils.ts                    |    100.0 |  100.0 |
--------------------------------------------------------
 All files                         |     93.8 |   94.0 |
--------------------------------------------------------
```