### PR TITLE
Fix fromTimer, throttle, concatMap 

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "tasks": {
     "bundle": "deno task --config lib/deno.json bundle && deno task --config react-lib/deno.json bundle",

--- a/lib/deno.json
+++ b/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/rp-lib",
-  "version": "0.0.6",
+  "version": "0.2.1",
   "exports": "./src/index.ts",
   "license": "MIT",
   "description": "A TypeScript Reactive Programming Library used as a tutorial for a course on Reactive Programming.",

--- a/lib/src/creation-operators.ts
+++ b/lib/src/creation-operators.ts
@@ -1,4 +1,4 @@
-import type { Observable } from './index.ts';
+import type { EmitterFunction, Observable } from './index.ts';
 import { Subject } from './index.ts';
 // import { EventEmitter } from "node:events";
 
@@ -65,24 +65,27 @@ export const range = (start: number, count: number): Observable<number> => {
 //   return eventObs$;
 // };
 
+const isFunction = <T>(fn: unknown): fn is EmitterFunction<T> => typeof fn === 'function';
+
 /**
  * Creates an Observable that will emit with a given delay a set of values.
  * @param delayMs - an interval in millisecond used to emit values.
- * @param values - the array of values to emit through the created Observable
+ * @param values - the array of values to emit through the created Observable or an emitter function that
+ * generates the values.
  * @returns an Observable
  */
 export const fromTimer = <T>(
   delayMs: number,
-  values: T[],
+  values: T[] | EmitterFunction<T>,
   start: 'onSubscribe' | 'now' = 'onSubscribe',
 ): Observable<T> => {
   const arrayObs$ = new Subject<T>();
   let idx = 1;
   const emitter = () => {
-    arrayObs$.emit(values[0]);
+    arrayObs$.emit(isFunction(values) ? values(0) : values[0]);
     const timer = setInterval(() => {
       if (idx < values.length) {
-        arrayObs$.emit(values[idx]);
+        arrayObs$.emit(isFunction(values) ? values(idx) : values[idx]);
         idx++;
       } else {
         clearInterval(timer);

--- a/lib/src/creation-operators.ts
+++ b/lib/src/creation-operators.ts
@@ -77,8 +77,9 @@ export const fromTimer = <T>(
   start: 'onSubscribe' | 'now' = 'onSubscribe',
 ): Observable<T> => {
   const arrayObs$ = new Subject<T>();
-  let idx = 0;
+  let idx = 1;
   const emitter = () => {
+    arrayObs$.emit(values[0]);
     const timer = setInterval(() => {
       if (idx < values.length) {
         arrayObs$.emit(values[idx]);

--- a/lib/src/trans-operators/concat.ts
+++ b/lib/src/trans-operators/concat.ts
@@ -39,9 +39,7 @@ export const concat =
         // Now we emit all cached values from the second observable
         secondSourceCache.forEach((value: I2) => result$.emit(value));
         // If the second observable has completed, we complete the result observable
-        if (secondSource$.isCompleted) {
-          result$.complete();
-        }
+        secondSource$.isCompleted && result$.complete();
       },
     });
     return result$;

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -1,4 +1,9 @@
-export type EmitterFunction<T> = (idx: number) => T;
+/**
+ * EmitterFunction is a function that takes a value and returns a
+ * value to be emitted by an observable. When the function returns
+ * null, the observable is completed.
+ */
+export type EmitterFunction<T> = (idx: number) => T | null;
 
 /**
  * A FullSubscriber listen to values emitted by an Observable and

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -1,3 +1,5 @@
+export type EmitterFunction<T> = (idx: number) => T;
+
 /**
  * A FullSubscriber listen to values emitted by an Observable and
  * to its error and complete events.

--- a/lib/tests/creation-operators.test.ts
+++ b/lib/tests/creation-operators.test.ts
@@ -41,16 +41,17 @@ Deno.test('Operator from creates an Observable emitting NO values', () => {
   assertSpyCalls(sub, 0);
 });
 
-Deno.test('Operator fromTimer creates an Observable emitting 1 value after 10ms', async () => {
+Deno.test('Operator fromTimer creates an Observable emitting 1 value right away and one after 10ms', async () => {
   const sub = spy();
   const complete = spy();
-  const obs$ = fromTimer(5, [1], 'onSubscribe');
+  const obs$ = fromTimer(5, [1, 2], 'onSubscribe');
   obs$.subscribe({
     next: sub,
     complete,
   });
-  await defer(20);
   assertSpyCalls(sub, 1);
+  await defer(20);
+  assertSpyCalls(sub, 2);
   assertSpyCalls(complete, 1);
 });
 

--- a/lib/tests/creation-operators.test.ts
+++ b/lib/tests/creation-operators.test.ts
@@ -1,5 +1,5 @@
 /// <reference lib="deno.ns" />
-
+import { expect } from 'jsr:@std/expect';
 import { assertSpyCallArg, assertSpyCalls, spy } from 'jsr:@std/testing/mock';
 // import { EventEmitter } from 'node:events';
 import {
@@ -126,6 +126,23 @@ Deno.test('Operator range creates an Observable emitting a sequence of numbers',
   assertSpyCallArg(sub, 0, 0, 1);
   assertSpyCallArg(sub, 1, 0, 2);
   assertSpyCallArg(sub, 2, 0, 3);
+});
+
+Deno.test('Use an EmitterFunction to generate values for an Observable', async () => {
+  const obs$ = fromTimer(10, (idx) => {
+    if (idx < 3) {
+      return idx;
+    }
+    return null;
+  });
+  const res: Array<number> = [];
+  obs$.subscribe({
+    next: (v) => res.push(v),
+    complete: () => {
+      expect(res).toEqual([0, 1, 2]);
+    },
+  });
+  await defer(50);
 });
 
 // Deno.test("Operator fromEvent creates an Observable emitting events", () => {

--- a/lib/tests/filter-operators/throttle.test.ts
+++ b/lib/tests/filter-operators/throttle.test.ts
@@ -15,3 +15,22 @@ Deno.test('throttle should emit only one value if the original observable emits 
     },
   });
 });
+
+Deno.test('throttle emit the last value after the throttle time after the source completes', async () => {
+  const source$ = fromArray([1, 2, 3, 4, 5]);
+  const result$ = throttle<number>(10)(source$);
+  const res: Array<number> = [];
+  let time = Date.now() - 10; // The first emission will be immediate
+  result$.subscribe({
+    next: (value: number) => {
+      expect(Date.now() - time).toBeGreaterThanOrEqual(10);
+      time = Date.now();
+      res.push(value);
+    },
+    complete: () => {
+      // First and last value should be emitted.
+      expect(res).toEqual([1, 5]);
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+});

--- a/lib/tests/filter-operators/throttle.test.ts
+++ b/lib/tests/filter-operators/throttle.test.ts
@@ -1,7 +1,8 @@
 import { expect } from 'jsr:@std/expect';
-import { fromArray, throttle } from '../../src/index.ts';
+import { fromArray, fromTimer, throttle } from '../../src/index.ts';
+import { defer } from '../utils.ts';
 
-Deno.test('throttle should emit only one value if the original observable emits all the values in the given time', () => {
+Deno.test('throttle should emit only one value if the original observable emits all the values in the given time', async () => {
   const source$ = fromArray([1, 2, 3, 4, 5]);
   const result$ = throttle<number>(10)(source$);
   const res: Array<number> = [];
@@ -11,13 +12,15 @@ Deno.test('throttle should emit only one value if the original observable emits 
       res.push(value);
     },
     complete: () => {
-      expect(res).toEqual([1]);
+      expect(res).toEqual([1, 5]);
     },
   });
+
+  await defer(30);
 });
 
 Deno.test('throttle emit the last value after the throttle time after the source completes', async () => {
-  const source$ = fromArray([1, 2, 3, 4, 5]);
+  const source$ = fromTimer(1, [1, 2, 3, 4, 5]);
   const result$ = throttle<number>(10)(source$);
   const res: Array<number> = [];
   let time = Date.now() - 10; // The first emission will be immediate
@@ -33,4 +36,23 @@ Deno.test('throttle emit the last value after the throttle time after the source
     },
   });
   await new Promise((resolve) => setTimeout(resolve, 50));
+});
+
+Deno.test('throttle emit all the source values if they are time spaced enough', async () => {
+  const source$ = fromTimer(11, [1, 2, 3, 4, 5]);
+  const result$ = throttle<number>(10)(source$);
+  const res: Array<number> = [];
+  let time = Date.now() - 10; // The first emission will be immediate
+  result$.subscribe({
+    next: (value: number) => {
+      expect(Date.now() - time).toBeGreaterThanOrEqual(10);
+      time = Date.now();
+      res.push(value);
+    },
+    complete: () => {
+      // First and last value should be emitted.
+      expect(res).toEqual([1, 2, 3, 4, 5]);
+    },
+  });
+  await defer(100);
 });

--- a/react-lib/deno.json
+++ b/react-lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/react-rp-lib",
-  "version": "0.0.1",
+  "version": "0.2.1",
   "license": "MIT",
   "description": "React utilities to work with rp-lib",
   "exports": "./src/index.ts",


### PR DESCRIPTION
## Summary 

- `fromTimer`: now emits the first value immediately/
- `fromTimer`: now can use an emitter function to generate values.
- `concatMap`: now completes when the source complete and no other observable is pending
- `throttle`: now emits the last value received from the source (with the right throttle delay) before completing.

Improved tests to verify these new fixes.

## Tests

```
--------------------------------------------------------
File                               | Branch % | Line % |
--------------------------------------------------------
 src/compose-pipe.ts               |    100.0 |  100.0 |
 src/creation-operators.ts         |     74.1 |   85.9 |
 src/filter-operators/debounce.ts  |    100.0 |   97.4 |
 src/filter-operators/filter.ts    |    100.0 |   94.7 |
 src/filter-operators/throttle.ts  |    100.0 |   97.3 |
 src/index.ts                      |    100.0 |  100.0 |
 src/observable.ts                 |    100.0 |  100.0 |
 src/signals/signal.ts             |     66.7 |   89.3 |
 src/trans-operators/concat-map.ts |     80.0 |   90.3 |
 src/trans-operators/concat.ts     |    100.0 |  100.0 |
 src/trans-operators/flat-map.ts   |    100.0 |   90.0 |
 src/trans-operators/map.ts        |    100.0 |  100.0 |
 src/trans-operators/merge.ts      |    100.0 |  100.0 |
 src/trans-operators/switch-map.ts |    100.0 |  100.0 |
 src/trans-operators/tap.ts        |    100.0 |  100.0 |
 tests/utils.ts                    |    100.0 |  100.0 |
--------------------------------------------------------
 All files                         |     89.0 |   93.9 |
--------------------------------------------------------
```
