### PR TITLE
Fix the build for the `react-rp-lib` module.

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "version": "0.3.1",
   "license": "MIT",
   "tasks": {
-    "bundle": "deno task --config lib/deno.json bundle && deno task --config react-lib/deno.json bundle",
+    "build": "deno task --config lib/deno.json build && deno task --config react-lib/deno.json build",
     "test": "deno test --coverage && deno coverage",
     "coverage": "deno test --coverage && deno coverage --html coverage && open coverage/html/index.html",
     "cli-demo": "deno run cli-demo/main.ts",
@@ -10,7 +10,8 @@
     "react-signals": "deno task --config react-signals/deno.json serve"
   },
   "compilerOptions": {
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "deno.ns"],
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "jsxImportSourceTypes": "@types/react"
@@ -34,14 +35,15 @@
       ]
     }
   },
-  "workspace": ["./lib", "./cli-demo", "./react-lib", "./react-signals"],
+  "workspace": {
+    "members": ["./lib", "./cli-demo", "./react-lib", "./react-signals"]
+  },
   "imports": {
     "@deno/vite-plugin": "npm:@deno/vite-plugin@^1.0.2",
+    "@micurs/rp-lib": "./lib/src/index.ts",
     "@vitejs/plugin-react-swc": "npm:@vitejs/plugin-react-swc@^3.7.1",
     "@types/react": "npm:@types/react@^18.3.11",
     "@types/react-dom": "npm:@types/react-dom@^18.3.1",
-    "@micurs/rp-lib": "./lib/src/index.ts",
-    "@micurs/react-rp-lib": "./react-lib/src/index.ts",
     "@std/assert": "jsr:@std/assert@1",
     "@std/path": "jsr:@std/path@^1.0.8",
     "vite": "npm:vite@^5.4.9",

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@micurs/rp-lib@~0.3.1": "0.3.1",
     "jsr:@std/assert@1": "1.0.10",
     "jsr:@std/assert@^1.0.10": "1.0.10",
     "jsr:@std/assert@^1.0.8": "1.0.8",
@@ -31,6 +32,9 @@
     "npm:vite@^5.4.9": "5.4.11_@types+node@22.5.4"
   },
   "jsr": {
+    "@micurs/rp-lib@0.3.1": {
+      "integrity": "7315742ab9b917f1fbc15b46af54ab793bdf353bbaad2f2904fadc18a6aaf59b"
+    },
     "@std/assert@1.0.8": {
       "integrity": "ebe0bd7eb488ee39686f77003992f389a06c3da1bbd8022184804852b2fa641b",
       "dependencies": [
@@ -2098,6 +2102,9 @@
         ]
       },
       "react-lib": {
+        "dependencies": [
+          "jsr:@micurs/rp-lib@~0.3.1"
+        ],
         "packageJson": {
           "dependencies": [
             "npm:@types/react@^18.3.11",

--- a/deno.lock
+++ b/deno.lock
@@ -1,8 +1,7 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@micurs/rp-lib@0.0.5": "0.0.5",
-    "jsr:@std/assert@1": "1.0.8",
+    "jsr:@std/assert@1": "1.0.10",
     "jsr:@std/assert@^1.0.10": "1.0.10",
     "jsr:@std/assert@^1.0.8": "1.0.8",
     "jsr:@std/expect@*": "1.0.8",
@@ -22,19 +21,16 @@
     "npm:postcss-import@14": "14.1.0_postcss@8.4.47",
     "npm:postcss@^8.4.32": "8.4.47",
     "npm:react-dom@^18.3.1": "18.3.1_react@18.3.1",
-    "npm:react@19": "19.0.0",
     "npm:react@^18.3.1": "18.3.1",
     "npm:rimraf@*": "6.0.1",
     "npm:tailwindcss@^3.3.6": "3.4.17_postcss@8.4.47",
     "npm:vite-plugin-dts@*": "4.4.0_typescript@5.7.2_vite@4.5.0__@types+node@22.5.4_@types+node@22.5.4",
     "npm:vite@*": "5.4.11_@types+node@22.5.4",
     "npm:vite@4.5.0": "4.5.0_@types+node@22.5.4",
+    "npm:vite@5.4.11": "5.4.11_@types+node@22.5.4",
     "npm:vite@^5.4.9": "5.4.11_@types+node@22.5.4"
   },
   "jsr": {
-    "@micurs/rp-lib@0.0.5": {
-      "integrity": "5b19c86e54aec4019c3b4653e0e8089a0c1c57c02a40760c856208f10c614d49"
-    },
     "@std/assert@1.0.8": {
       "integrity": "ebe0bd7eb488ee39686f77003992f389a06c3da1bbd8022184804852b2fa641b",
       "dependencies": [
@@ -1306,7 +1302,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": [
         "loose-envify",
-        "react@18.3.1",
+        "react",
         "scheduler"
       ]
     },
@@ -1315,9 +1311,6 @@
       "dependencies": [
         "loose-envify"
       ]
-    },
-    "react@19.0.0": {
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="
     },
     "read-cache@1.0.0": {
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
@@ -2105,12 +2098,10 @@
         ]
       },
       "react-lib": {
-        "dependencies": [
-          "jsr:@micurs/rp-lib@0.0.5"
-        ],
         "packageJson": {
           "dependencies": [
-            "npm:react@19"
+            "npm:@types/react@^18.3.11",
+            "npm:react@^18.3.1"
           ]
         }
       },

--- a/lib/deno.json
+++ b/lib/deno.json
@@ -11,7 +11,7 @@
     ]
   },
   "tasks": {
-    "bundle": "deno run --allow-all npm:vite build --config ./vite.config.ts",
+    "build": "deno run --allow-all --node-modules-dir npm:vite build --config ./vite.config.ts",
     "dev": "deno test --watch",
     "test": "deno test --coverage && deno coverage",
     "coverage": "deno test --coverage && deno coverage --html coverage && open coverage/html/index.html"

--- a/react-lib/.npmrc
+++ b/react-lib/.npmrc
@@ -1,0 +1,1 @@
+@jsr:registry=https://npm.jsr.io

--- a/react-lib/deno.json
+++ b/react-lib/deno.json
@@ -7,13 +7,11 @@
   "publish": {
     "include": [
       "readme.md",
+      "dist/**/*",
       "src/**/*"
     ]
   },
   "tasks": {
-    "bundle": "deno run --allow-all npm:vite build --config ./vite.config.ts"
-  },
-  "imports": {
-    "@micurs/rp-lib": "jsr:@micurs/rp-lib@0.0.5"
+    "build": "deno run --allow-all  --node-modules-dir npm:vite build --config ./vite.config.ts"
   }
 }

--- a/react-lib/deno.json
+++ b/react-lib/deno.json
@@ -13,5 +13,8 @@
   },
   "tasks": {
     "build": "deno run --allow-all  --node-modules-dir npm:vite build --config ./vite.config.ts"
+  },
+  "imports": {
+    "@micurs/rp-lib": "jsr:@micurs/rp-lib@^0.3.1"
   }
 }

--- a/react-lib/package.json
+++ b/react-lib/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "dependencies": {
-    "react": "^19.0.0"
+    "react": "^18.3.1",
+    "@types/react": "^18.3.11"
+  },
+  "devDependencies": {
+    "@micurs/rp-lib": "workspace:*"
   }
 }

--- a/react-lib/src/use-observable.ts
+++ b/react-lib/src/use-observable.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import type { Observable } from 'jsr:@micurs/rp-lib';
+import type { Observable } from '@micurs/rp-lib';
 
 /**
  * A simple hook that subscribes to an observable and returns its current value.
@@ -11,7 +11,7 @@ import type { Observable } from 'jsr:@micurs/rp-lib';
 export const useObservable = <T>(
   observable: Observable<T>,
   initialValue: T,
-): T => {
+): T | undefined => {
   const [_, setValue] = useState(initialValue);
   useEffect(() => {
     const subscription = observable.subscribe(setValue);

--- a/react-lib/src/use-signal.ts
+++ b/react-lib/src/use-signal.ts
@@ -1,5 +1,5 @@
-import * as React from "react";
-import type { Signal } from "jsr:@micurs/rp-lib";
+import { useEffect, useState } from 'react';
+import type { Signal } from '@micurs/rp-lib';
 
 /**
  * Simple custom hook that can be used to integrate react with rp-lib Signal class.
@@ -8,8 +8,8 @@ import type { Signal } from "jsr:@micurs/rp-lib";
  * @returns a value as emitted by the signal or the default value if the signal has not yet emitted a value.
  */
 export function useSignal<M>(signal: Signal<M>, def: NonNullable<M>): M {
-  const [, setState] = React.useState({});
-  React.useEffect(() => {
+  const [, setState] = useState({});
+  useEffect(() => {
     const clearEffect = signal.addEffect(() => setState({}));
     return () => clearEffect();
   }, [signal]);

--- a/react-lib/vite.config.ts
+++ b/react-lib/vite.config.ts
@@ -1,41 +1,58 @@
 /// <reference lib="deno.ns" />
 
-import { join } from "@std/path";
-import { defineConfig, type Plugin } from "vite";
-import dts from "vite-plugin-dts";
-import deno from "@deno/vite-plugin";
+import { join } from '@std/path';
+import { defineConfig, type Plugin } from 'vite';
+import dts from 'vite-plugin-dts';
+import deno from '@deno/vite-plugin';
 
-const rpLibPath = join(Deno.cwd(), "../lib/src/index.ts");
-console.log("@micurs/rp-lib", rpLibPath);
+const rpLibPath = join(Deno.cwd(), '../lib/src/index.ts');
 
 export default defineConfig({
   plugins: [
     deno(),
     dts({
-      include: "src",
+      include: 'src',
       rollupTypes: true,
-      insertTypesEntry: true,
+      compilerOptions: {
+        paths: {
+          '@micurs/rp-lib': [rpLibPath],
+        },
+      },
+      beforeWriteFile: (filePath, content) => {
+        if (!filePath.endsWith('index.d.ts')) {
+          return {
+            filePath,
+            content,
+          };
+        }
+        // Replace the import path with the correct library reference.
+        return ({
+          filePath,
+          content: content.replace(/..\/..\/lib\/src\/index.ts/g, '@micurs/rp-lib'),
+        });
+      },
     }) as Plugin,
   ],
   resolve: {
     alias: {
-      "@micurs/rp-lib": rpLibPath,
+      '@micurs/rp-lib': rpLibPath,
     },
   },
   build: {
-    minify: "esbuild",
+    minify: 'esbuild',
     sourcemap: true,
+    emptyOutDir: true,
     reportCompressedSize: true,
     lib: {
-      entry: "./src/index.ts",
-      formats: ["es"],
+      entry: './src/index.ts',
+      formats: ['es'],
     },
     rollupOptions: {
-      external: ["react", "@micurs/rp-lib"],
+      external: ['react', '@micurs/rp-lib'],
       output: {
         compact: true,
-        dir: "dist",
-        entryFileNames: "index.js",
+        dir: 'dist',
+        entryFileNames: 'index.js',
       },
     },
   },


### PR DESCRIPTION
## Summary

- Fix build errors: `error TS2792: Cannot find module '@micurs/rp-lib'.`  when building `react-lib`. 
- Added custom code in `react-lib/vite.config.ts` to generate imports to `rp-lib` using the `@micurs/rp-lib` notation.


