### PR TITLE
Fix throttle and add useObservables to `react-rp-lib`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "tasks": {
     "update:versions": "deno --allow-read --allow-write --allow-env scripts/update-versions.ts",

--- a/lib/deno.json
+++ b/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/rp-lib",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "exports": "./src/index.ts",
   "license": "MIT",
   "description": "A TypeScript Reactive Programming Library used as a tutorial for a course on Reactive Programming.",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/rp-lib",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "module": "dist/index.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts"

--- a/lib/src/filter-operators/filter.ts
+++ b/lib/src/filter-operators/filter.ts
@@ -22,7 +22,7 @@ export const filter = <T>(predicate: Predicate<T>): Operator<T, T> => {
         },
         error: (err) => result$.error(err),
         complete: () => result$.complete(),
-      });
+      }, true);
     });
     return result$;
   };

--- a/lib/src/filter-operators/throttle.ts
+++ b/lib/src/filter-operators/throttle.ts
@@ -1,7 +1,5 @@
-import { l } from 'vite';
 import type { Observable, Operator } from '../index.ts';
 import { Subject } from '../index.ts';
-import { s } from 'vite';
 
 /**
  * The throttle operator creates a new observable that only emits

--- a/lib/src/filter-operators/throttle.ts
+++ b/lib/src/filter-operators/throttle.ts
@@ -1,5 +1,7 @@
+import { l } from 'vite';
 import type { Observable, Operator } from '../index.ts';
 import { Subject } from '../index.ts';
+import { s } from 'vite';
 
 /**
  * The throttle operator creates a new observable that only emits
@@ -13,8 +15,13 @@ export const throttle = <T>(time: number): Operator<T, T> => {
     const result$ = new Subject<T>();
     let lastSourceValue: T | undefined = undefined;
     let lastEmissionTime: number | undefined = undefined;
+    let _timeout: ReturnType<typeof setTimeout> | undefined = undefined;
     source$.subscribe({
       next: (val: T) => {
+        if (_timeout !== undefined) {
+          clearTimeout(_timeout);
+          _timeout = undefined;
+        }
         if (lastEmissionTime === undefined) {
           result$.emit(val);
           lastEmissionTime = Date.now();
@@ -27,18 +34,25 @@ export const throttle = <T>(time: number): Operator<T, T> => {
           lastSourceValue = undefined;
         } else {
           lastSourceValue = val;
+          if (lastSourceValue === undefined) {
+            return;
+          }
+          _timeout = setTimeout(() => {
+            if (result$.isCompleted) {
+              return;
+            }
+            lastSourceValue !== undefined && result$.emit(lastSourceValue);
+            lastEmissionTime = Date.now();
+            lastSourceValue = undefined;
+            if (source$.isCompleted) {
+              result$.complete();
+            }
+          }, time - deltaTime);
         }
       },
       error: (err: Error) => result$.error(err),
       complete: () => {
-        if (lastSourceValue !== undefined) {
-          setTimeout(() => {
-            result$.emit(lastSourceValue!);
-            result$.complete();
-          }, time - (Date.now() - lastEmissionTime!));
-          return;
-        }
-        result$.complete();
+        lastSourceValue === undefined && result$.complete();
       },
     });
     return result$;

--- a/lib/tests/filter-operators/throttle.test.ts
+++ b/lib/tests/filter-operators/throttle.test.ts
@@ -20,22 +20,25 @@ Deno.test('throttle should emit only one value if the original observable emits 
 });
 
 Deno.test('throttle emit the last value after the throttle time after the source completes', async () => {
-  const source$ = fromTimer(1, [1, 2, 3, 4, 5]);
-  const result$ = throttle<number>(10)(source$);
+  const throttleTime = 100;
+  const source$ = fromTimer(20, [1, 2, 3, 4, 5, 6]);
+  const result$ = throttle<number>(100)(source$);
   const res: Array<number> = [];
-  let time = Date.now() - 10; // The first emission will be immediate
+  let time = Date.now() - throttleTime; // The first emission will be immediate
   result$.subscribe({
     next: (value: number) => {
-      expect(Date.now() - time).toBeGreaterThanOrEqual(10);
-      time = Date.now();
+      const now = Date.now();
+      // console.log(value, ' > Delta Time: ', now - time);
+      expect(now - time).toBeGreaterThanOrEqual(throttleTime);
+      time = now;
       res.push(value);
     },
     complete: () => {
       // First and last value should be emitted.
-      expect(res).toEqual([1, 5]);
+      expect(res).toEqual([1, 5, 6]);
     },
   });
-  await new Promise((resolve) => setTimeout(resolve, 50));
+  await new Promise((resolve) => setTimeout(resolve, throttleTime * 3));
 });
 
 Deno.test('throttle emit all the source values if they are time spaced enough', async () => {

--- a/react-lib/deno.json
+++ b/react-lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/react-rp-lib",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "description": "React utilities to work with rp-lib",
   "exports": "./src/index.ts",

--- a/react-lib/package.json
+++ b/react-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/react-rp-lib",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "module": "dist/index.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/react-lib/readme.md
+++ b/react-lib/readme.md
@@ -14,8 +14,8 @@ The library provides a set of hooks to interact with the `rp-lib` library
 ### Observer hook
 
 ```tsx
-import { Subject } from "@micurs/rp-lib";
-import { useObservable } from "@micurs/react-rp-lib";
+import { Subject } from '@micurs/rp-lib';
+import { useObservable } from '@micurs/react-rp-lib';
 
 const counter$ = new Subject<number>(1);
 
@@ -29,8 +29,8 @@ const counterComponent = () => {
 ### Signal hook
 
 ```tsx
-import { Signal } from "@micurs/rp-lib";
-import { useSignal } from "@micurs/react-rp-lib";
+import { Signal } from '@micurs/rp-lib';
+import { useSignal } from '@micurs/react-rp-lib';
 
 const signal = new Signal(10);
 

--- a/react-lib/src/use-observable.ts
+++ b/react-lib/src/use-observable.ts
@@ -1,21 +1,43 @@
-import { useEffect, useState } from 'react';
-import type { Observable } from '@micurs/rp-lib';
+import { useEffect, useRef, useState } from 'react';
+import { Subject } from '@micurs/rp-lib';
+import type { Observable, Operator } from '@micurs/rp-lib';
 
 /**
  * A simple hook that subscribes to an observable and returns its current value.
  * The hook will re-set the value whenever the observable emits a new value.
- * @param observable The observable to subscribe to.
  * @param initialValue The initial value to use until the observable emits a value.
  * @returns The current value of the observable.
  */
 export const useObservable = <T>(
-  observable: Observable<T>,
-  initialValue: T,
+  obs$: Observable<T>,
 ): T | undefined => {
-  const [_, setValue] = useState(initialValue);
+  const [, setState] = useState({}); // A dummy used to trigger a re-render
   useEffect(() => {
-    const subscription = observable.subscribe(setValue);
-    return () => subscription.unsubscribe();
-  }, [observable]);
-  return observable.value;
+    obs$.subscribe(() => setState({}));
+  }, [obs$]);
+  return obs$.value;
+};
+
+/**
+ * A hook that creates a source observable and an output observable using the given operator.
+ * The hook returns the current value of the source and the output observables and a function
+ * to submit values to the source observable.
+ * Every time the source observable or the output observable emits a new value, the hook will
+ * force a re-render of the component.
+ * @param v - the initial value for the source observable
+ * @param operator - the operator used to create the output observable
+ * @returns a triplet with the value of the source, the value of the output
+ * and a function to submit values to the source
+ */
+export const useObservables = <A, B>(
+  v: A,
+  operator: Operator<A, B>,
+): [A | undefined, B | undefined, (v: A) => void] => {
+  const source$ = useRef(new Subject(v));
+  const out$ = useRef(operator(source$.current));
+  return [
+    useObservable(source$.current),
+    useObservable(out$.current),
+    (v: A) => source$.current.emit(v),
+  ];
 };


### PR DESCRIPTION
## Summary
 
- `throttle` operator fix: now emits the last value regardless if the source completes or not.
- Fix (implement) `useObservable`
- Add `useObservables` to `react-rp-lib`  to create a source observable and a derived one using an operator.

## Test

```
--------------------------------------------------------
File                               | Branch % | Line % |
--------------------------------------------------------
 src/compose-pipe.ts               |    100.0 |  100.0 |
 src/creation-operators.ts         |     75.0 |   90.4 |
 src/filter-operators/debounce.ts  |    100.0 |   97.4 |
 src/filter-operators/filter.ts    |    100.0 |   94.7 |
 src/filter-operators/throttle.ts  |     85.7 |   75.5 |
 src/index.ts                      |    100.0 |  100.0 |
 src/observable.ts                 |    100.0 |  100.0 |
 src/signals/signal.ts             |     66.7 |   74.6 |
 src/trans-operators/concat-map.ts |     80.0 |   90.3 |
 src/trans-operators/concat.ts     |    100.0 |  100.0 |
 src/trans-operators/flat-map.ts   |    100.0 |   90.0 |
 src/trans-operators/map.ts        |    100.0 |  100.0 |
 src/trans-operators/merge.ts      |    100.0 |  100.0 |
 src/trans-operators/switch-map.ts |    100.0 |  100.0 |
 src/trans-operators/tap.ts        |    100.0 |  100.0 |
 tests/utils.ts                    |    100.0 |  100.0 |
--------------------------------------------------------
 All files                         |     89.4 |   91.3 |
--------------------------------------------------------
```
