### PR TITLE
Improve throttle (refactor) and fix useObservables() recreating multiple copies of the observables!

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "tasks": {
     "update:versions": "deno --allow-read --allow-write --allow-env scripts/update-versions.ts",

--- a/lib/deno.json
+++ b/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/rp-lib",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "exports": "./src/index.ts",
   "license": "MIT",
   "description": "A TypeScript Reactive Programming Library used as a tutorial for a course on Reactive Programming.",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/rp-lib",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "module": "dist/index.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts"

--- a/react-lib/deno.json
+++ b/react-lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/react-rp-lib",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "description": "React utilities to work with rp-lib",
   "exports": "./src/index.ts",

--- a/react-lib/package.json
+++ b/react-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/react-rp-lib",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "module": "dist/index.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/react-lib/src/use-observable.ts
+++ b/react-lib/src/use-observable.ts
@@ -33,8 +33,12 @@ export const useObservables = <A, B>(
   v: A,
   operator: Operator<A, B>,
 ): [A | undefined, B | undefined, (v: A) => void] => {
-  const source$ = useRef(new Subject(v));
-  const out$ = useRef(operator(source$.current));
+  const source$ = useRef(null);
+  const out$ = useRef(null);
+  if (source$.current === null) {
+    source$.current = new Subject(v);
+    out$.current = operator(source$.current);
+  }
   return [
     useObservable(source$.current),
     useObservable(out$.current),


### PR DESCRIPTION
## Summary

- Improved `throttle` operator by removing unnecessary checks.
- Fix the `useObservables` hook to avoid recreating multiple copies of the same observables at each rendering!

### Tests

```
--------------------------------------------------------
File                               | Branch % | Line % |
--------------------------------------------------------
 src/compose-pipe.ts               |    100.0 |  100.0 |
 src/creation-operators.ts         |     75.0 |   90.4 |
 src/filter-operators/debounce.ts  |    100.0 |   97.4 |
 src/filter-operators/filter.ts    |    100.0 |   94.7 |
 src/filter-operators/throttle.ts  |     86.2 |   70.2 |
 src/index.ts                      |    100.0 |  100.0 |
 src/observable.ts                 |    100.0 |  100.0 |
 src/signals/signal.ts             |     66.7 |   74.6 |
 src/trans-operators/concat-map.ts |     80.0 |   90.3 |
 src/trans-operators/concat.ts     |    100.0 |  100.0 |
 src/trans-operators/flat-map.ts   |    100.0 |   90.0 |
 src/trans-operators/map.ts        |    100.0 |  100.0 |
 src/trans-operators/merge.ts      |    100.0 |  100.0 |
 src/trans-operators/switch-map.ts |    100.0 |  100.0 |
 src/trans-operators/tap.ts        |    100.0 |  100.0 |
 tests/utils.ts                    |    100.0 |  100.0 |
--------------------------------------------------------
 All files                         |     89.2 |   90.9 |
--------------------------------------------------------
```