### PR TITLE
Add useObservables and useOperator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,9 @@
     "activityBar.activeBackground": "#0e156d",
     "activityBar.activeBorder": "#e6d627",
     "activityBar.foreground": "#e6d627",
-    "activityBar.inactiveForeground": "#a59e53",
+    "activityBar.inactiveForeground": "#a59e53"
   },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,6 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@micurs/rp-lib@~0.3.1": "0.3.1",
     "jsr:@std/assert@1": "1.0.10",
     "jsr:@std/assert@^1.0.10": "1.0.10",
     "jsr:@std/assert@^1.0.8": "1.0.8",
@@ -43,9 +42,6 @@
     "npm:vite@^5.4.9": "5.4.11_@types+node@22.5.4"
   },
   "jsr": {
-    "@micurs/rp-lib@0.3.1": {
-      "integrity": "7315742ab9b917f1fbc15b46af54ab793bdf353bbaad2f2904fadc18a6aaf59b"
-    },
     "@std/assert@1.0.8": {
       "integrity": "ebe0bd7eb488ee39686f77003992f389a06c3da1bbd8022184804852b2fa641b",
       "dependencies": [
@@ -2440,7 +2436,7 @@
       },
       "react-lib": {
         "dependencies": [
-          "jsr:@micurs/rp-lib@~0.3.1"
+          "jsr:@micurs/rp-lib@0.4"
         ],
         "packageJson": {
           "dependencies": [

--- a/lib/tests/filter-operators/throttle.test.ts
+++ b/lib/tests/filter-operators/throttle.test.ts
@@ -20,22 +20,21 @@ Deno.test('throttle should emit only one value if the original observable emits 
 });
 
 Deno.test('throttle emit the last value after the throttle time after the source completes', async () => {
-  const throttleTime = 100;
-  const source$ = fromTimer(20, [1, 2, 3, 4, 5, 6]);
-  const result$ = throttle<number>(100)(source$);
+  const throttleTime = 300;
+  const source$ = fromTimer(100, [1, 2, 3, 4]);
+  const result$ = throttle<number>(throttleTime)(source$);
   const res: Array<number> = [];
   let time = Date.now() - throttleTime; // The first emission will be immediate
   result$.subscribe({
     next: (value: number) => {
       const now = Date.now();
-      // console.log(value, ' > Delta Time: ', now - time);
       expect(now - time).toBeGreaterThanOrEqual(throttleTime);
       time = now;
       res.push(value);
     },
     complete: () => {
       // First and last value should be emitted.
-      expect(res).toEqual([1, 5, 6]);
+      expect(res).toEqual([1, 3, 4]);
     },
   });
   await new Promise((resolve) => setTimeout(resolve, throttleTime * 3));

--- a/react-lib/deno.json
+++ b/react-lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/react-rp-lib",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "React utilities to work with rp-lib",
   "exports": "./src/index.ts",
@@ -12,9 +12,12 @@
     ]
   },
   "tasks": {
-    "build": "deno run --allow-all  --node-modules-dir npm:vite build --config ./vite.config.ts"
+    "build": "deno run --allow-all  --node-modules-dir npm:vite build --config ./vite.config.ts",
+    "dev": "deno test --allow-env --watch",
+    "test": "deno test --allow-env --coverage && deno coverage",
+    "coverage": "deno test --allow-env --coverage && deno coverage --html coverage && open coverage/html/index.html"
   },
   "imports": {
-    "@micurs/rp-lib": "jsr:@micurs/rp-lib@^0.3.1"
+    "@micurs/rp-lib": "jsr:@micurs/rp-lib@^0.4.0"
   }
 }

--- a/react-lib/package.json
+++ b/react-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/react-rp-lib",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "module": "dist/index.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/react-lib/src/index.ts
+++ b/react-lib/src/index.ts
@@ -1,2 +1,4 @@
 export * from './use-observable.ts';
+export * from './use-observables.ts';
+export * from './use-operator.ts';
 export * from './use-signal.ts';

--- a/react-lib/src/use-observable.ts
+++ b/react-lib/src/use-observable.ts
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
-import { Subject } from '@micurs/rp-lib';
-import type { Observable, Operator } from '@micurs/rp-lib';
+import { useEffect, useState } from 'react';
+import type { Observable } from '@micurs/rp-lib';
 
 /**
  * A simple hook that subscribes to an observable and returns its current value.
@@ -11,37 +10,12 @@ import type { Observable, Operator } from '@micurs/rp-lib';
 export const useObservable = <T>(
   obs$: Observable<T>,
 ): T | undefined => {
-  const [, setState] = useState({}); // A dummy used to trigger a re-render
+  const [value, setState] = useState(() => obs$.value); // A dummy used to trigger a re-render
   useEffect(() => {
-    obs$.subscribe(() => setState({}));
+    const subscription = obs$.subscribe(() => setState(() => obs$.value), true);
+    return () => {
+      subscription.unsubscribe(); // Cleanup subscription
+    };
   }, [obs$]);
-  return obs$.value;
-};
-
-/**
- * A hook that creates a source observable and an output observable using the given operator.
- * The hook returns the current value of the source and the output observables and a function
- * to submit values to the source observable.
- * Every time the source observable or the output observable emits a new value, the hook will
- * force a re-render of the component.
- * @param v - the initial value for the source observable
- * @param operator - the operator used to create the output observable
- * @returns a triplet with the value of the source, the value of the output
- * and a function to submit values to the source
- */
-export const useObservables = <A, B>(
-  v: A,
-  operator: Operator<A, B>,
-): [A | undefined, B | undefined, (v: A) => void] => {
-  const source$ = useRef(null);
-  const out$ = useRef(null);
-  if (source$.current === null) {
-    source$.current = new Subject(v);
-    out$.current = operator(source$.current);
-  }
-  return [
-    useObservable(source$.current),
-    useObservable(out$.current),
-    (v: A) => source$.current.emit(v),
-  ];
+  return value;
 };

--- a/react-lib/src/use-observables.ts
+++ b/react-lib/src/use-observables.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import type { Observable, ObservableValues } from '../../lib/src/types.ts';
+import { mergeArray } from '../../lib/src/index.ts';
+
+// type P = [Observable<number>, Observable<string>, string];
+// type P2 = ObservableValues<P>; // [number, string]
+
+/**
+ * A hook that subscribes to an array of observables and returns their current values.
+ * If any of the observables emits a new value, the hook will force a re-render of the component.
+ * @param observables - an array of observables
+ * @returns an array with the current values of the observables
+ */
+export const useObservables = <
+  Obs extends [Observable<unknown>, ...ReadonlyArray<Observable<unknown>>],
+>(
+  observables: Obs,
+): ObservableValues<Obs> => {
+  const [values, setState] = useState(observables.map((o) => o.value));
+  useEffect(() => {
+    const subscription = mergeArray(observables).subscribe((_) => {
+      setState(observables.map((o) => o.value));
+    }, false);
+    return () => {
+      subscription.unsubscribe(); // Cleanup subscription
+    };
+  }, [observables]);
+  return values as ObservableValues<Obs>;
+};

--- a/react-lib/src/use-operator.ts
+++ b/react-lib/src/use-operator.ts
@@ -1,0 +1,39 @@
+import { useCallback, useMemo } from 'react';
+import { Subject } from '@micurs/rp-lib';
+import type { Observable, Operator } from '@micurs/rp-lib';
+
+import { useObservable } from './index.ts';
+
+/**
+ * A hook that creates a source observable and an output observable using the given operator.
+ * The hook returns the current value of the source and the output observables and a function
+ * to submit values to the source observable.
+ * Every time the source observable or the output observable emits a new value, the hook will
+ * force a re-render of the component.
+ * > **Note:** This hook will always cause an initial rerender after the first pass since it
+ * applies the operator to the source that cause the output value to change from an initial
+ * `undefined` to the calculated value.
+ * @param val - the initial value for the source observable
+ * @param operator - the operator used to create the output observable
+ * @returns a triplet with the value of the source, the value of the output
+ * and a function to submit values to the source
+ */
+export const useOperator = <A, B>(
+  val: A,
+  operator: Operator<A, B>,
+): [A | undefined, B | undefined, (v: A) => void] => {
+  const source$ = useMemo<Observable<A> | null>(() => new Subject(val), [val]);
+  const out$ = useMemo<Observable<B> | null>(() => {
+    return operator(source$);
+  }, [val, operator]);
+  const setter = useCallback((newVal: A) => {
+    source$ && source$.emit(newVal);
+  }, [source$]);
+  const outValue = useObservable<B>(out$);
+  console.log('Returning values', outValue);
+  return [
+    source$.value,
+    outValue,
+    setter,
+  ];
+};

--- a/react-lib/tests/use-observable.test.tsx
+++ b/react-lib/tests/use-observable.test.tsx
@@ -1,0 +1,67 @@
+/// <reference lib="deno.ns" />
+import { expect } from 'jsr:@std/expect';
+
+import 'global-jsdom/register';
+import { render, waitFor, configure } from '@testing-library/react';
+
+import { Subject } from 'jsr:@micurs/rp-lib';
+import { useObservable } from '../src/index.ts';
+
+configure({reactStrictMode: false});
+
+Deno.test('useObservable should return the current value of the observable', () => {
+  const obs$ = new Subject(42);
+  const TestComponent = () => {
+    const result = useObservable(obs$);
+    return <span>{result}</span>;
+  };
+
+  const { container } = render(<TestComponent />);
+  expect(container.innerHTML).toBe('<span>42</span>');
+});
+
+
+Deno.test('useObservable should re-render when emitting a new value on the observable', async () => {
+  const obs$ = new Subject(42);
+  const TestComponent = () => {
+    const result = useObservable(obs$);
+    return <span>{result}</span>;
+  };
+
+  const { container } = render(<TestComponent />);
+
+  obs$.emit(99);
+
+  // Wait for the DOM to reflect the new emitted value
+  await waitFor(() => {
+    expect(container.innerHTML).toBe('<span>99</span>');
+  });
+});
+
+Deno.test('useObservable should re-render once when the observable emit one more value', async () => {
+  const obs$ = new Subject(42);
+  const renderCount = { count: 0 };
+
+  const TestComponent = () => {
+    renderCount.count += 1;
+    const result = useObservable(obs$);
+    return <span>{result}</span>;
+  };
+
+  const { container } = render(<TestComponent />);
+
+  // Initial render
+  expect(renderCount.count).toBe(1);
+
+  // Emit a new value
+  obs$.emit(99);
+
+  // Wait for the DOM to reflect the new emitted value
+  await waitFor(() => {
+    expect(container.innerHTML).toBe('<span>99</span>');
+  });
+
+  // Verify the component re-rendered exactly once
+  expect(renderCount.count).toBe(2);
+});
+

--- a/react-lib/tests/use-observables.test.tsx
+++ b/react-lib/tests/use-observables.test.tsx
@@ -1,0 +1,46 @@
+/// <reference lib="deno.ns" />
+import { expect } from 'jsr:@std/expect';
+import 'global-jsdom/register';
+import { configure, render, waitFor } from '@testing-library/react';
+
+import { useObservables } from '../src/index.ts';
+import { Subject } from '../../lib/src/index.ts';
+
+configure({ reactStrictMode: false });
+
+Deno.test('useObservables allow to react to two Observers.', () => {
+  let renderCount = 0;
+  const obs1$ = new Subject(10);
+  const obs2$ = new Subject(20);
+  const TestComponent = () => {
+    renderCount += 1;
+    const [result1, result2] = useObservables([obs1$, obs2$]);
+    return <span>{result1},{result2}</span>;
+  };
+  const { container } = render(<TestComponent />);
+
+  expect(container.innerHTML).toBe('<span>10,20</span>');
+  expect(renderCount).toBe(1);
+});
+
+Deno.test('useObservables should re-render when emitting a new value on any observable passed', async () => {
+  let renderCount = 0;
+  const obs1$ = new Subject('test');
+  const obs2$ = new Subject('this');
+  const obs3$ = new Subject('code');
+  const TestComponent = () => {
+    renderCount += 1;
+    const [result1, result2, result3] = useObservables([obs1$, obs2$, obs3$]);
+    return <span>{result1} {result2} {result3}</span>;
+  };
+  const { container } = render(<TestComponent />);
+  expect(container.innerHTML).toBe('<span>test this code</span>');
+  expect(renderCount).toBe(1);
+
+  obs3$.emit('component');
+
+  await waitFor(() => {
+    expect(renderCount).toBe(2);
+    expect(container.innerHTML).toBe('<span>test this component</span>');
+  });
+});

--- a/react-lib/tests/use-operator.test.tsx
+++ b/react-lib/tests/use-operator.test.tsx
@@ -1,0 +1,55 @@
+import { expect } from 'jsr:@std/expect';
+
+import 'global-jsdom/register';
+import { configure, fireEvent, render, waitFor } from '@testing-library/react';
+
+import { map } from 'jsr:@micurs/rp-lib';
+import { useOperator } from '../src/index.ts';
+
+configure({ reactStrictMode: false });
+
+Deno.test('useOperator should return the current values of the observables', () => {
+  const initialValue = 42;
+  let renderCount = 0;
+  const operator = map((v: number) => v * 2);
+  const TestComponent = () => {
+    const [srcValue, outValue, _] = useOperator(initialValue, operator);
+    renderCount++;
+    return <span>{srcValue},{outValue}</span>;
+  };
+
+  const { container } = render(<TestComponent />);
+  expect(container.innerHTML).toBe('<span>42,84</span>');
+  expect(renderCount).toBe(2);
+});
+
+Deno.test('useOperator should rerender when the setter function is called', async () => {
+  let renderCount = 0;
+  const initialValue = 42;
+  const operator = map((v: number) => v * 2);
+  const TestComponent = () => {
+    const [sourceVal, outValue, setSource] = useOperator<number, number>(initialValue, operator);
+    const handleClick = () => setSource(10);
+    renderCount++;
+    return (
+      <>
+        <span>{sourceVal},{outValue}</span>
+        <button onClick={handleClick}>Emit</button>
+      </>
+    );
+  };
+
+  const { container, getByText } = render(<TestComponent />);
+
+  expect(renderCount).toBe(2);
+
+  // Locate and click the button
+  const button = getByText('Emit');
+  fireEvent.click(button);
+
+  // Wait for the DOM to reflect the new emitted value
+  await waitFor(() => {
+    expect(container.innerHTML).toContain('<span>10,20</span>');
+  });
+  expect(renderCount).toBe(3);
+});


### PR DESCRIPTION
## Summary

* Adding new hooks and rename the previous `useObservables` to `useOperator`.
* Add tests using `testing-library/react` and `global-jsdom`.

## Tests

```

ok | 77 passed | 0 failed (7s)

-------------------------------------------------------------
File                                    | Branch % | Line % |
-------------------------------------------------------------
 lib/src/compose-pipe.ts                |    100.0 |  100.0 |
 lib/src/creation-operators.ts          |     75.0 |   90.4 |
 lib/src/filter-operators/debounce.ts   |    100.0 |   97.4 |
 lib/src/filter-operators/filter.ts     |    100.0 |   94.7 |
 lib/src/filter-operators/throttle.ts   |     87.5 |   91.5 |
 lib/src/index.ts                       |    100.0 |  100.0 |
 lib/src/observable.ts                  |    100.0 |  100.0 |
 lib/src/signals/signal.ts              |     66.7 |   74.6 |
 lib/src/trans-operators/concat-map.ts  |     80.0 |   90.3 |
 lib/src/trans-operators/concat.ts      |    100.0 |  100.0 |
 lib/src/trans-operators/flat-map.ts    |    100.0 |   90.0 |
 lib/src/trans-operators/map.ts         |    100.0 |  100.0 |
 lib/src/trans-operators/merge.array.ts |    100.0 |  100.0 |
 lib/src/trans-operators/merge.ts       |    100.0 |  100.0 |
 lib/src/trans-operators/switch-map.ts  |    100.0 |  100.0 |
 lib/src/trans-operators/tap.ts         |    100.0 |  100.0 |
 lib/tests/utils.ts                     |    100.0 |  100.0 |
 react-lib/src/index.ts                 |    100.0 |  100.0 |
 react-lib/src/use-observable.ts        |    100.0 |   75.0 |
 react-lib/src/use-observables.ts       |    100.0 |  100.0 |
 react-lib/src/use-operator.ts          |    100.0 |  100.0 |
 react-lib/src/use-signal.ts            |    100.0 |   11.1 |
-------------------------------------------------------------
 All files                              |     90.5 |   91.8 |
-------------------------------------------------------------
```
