### PR TITLE
Fix map, mergeArray and observable

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "tasks": {
     "update:versions": "deno --allow-read --allow-write --allow-env scripts/update-versions.ts",

--- a/lib/deno.json
+++ b/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/rp-lib",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "exports": "./src/index.ts",
   "license": "MIT",
   "description": "A TypeScript Reactive Programming Library used as a tutorial for a course on Reactive Programming.",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@micurs/rp-lib",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "module": "dist/index.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts"

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -4,7 +4,7 @@ export * from './creation-operators.ts';
 export * from './trans-operators/tap.ts';
 export * from './trans-operators/map.ts';
 export * from './trans-operators/merge.ts';
-export * from './trans-operators/merge.array.ts';
+export * from './trans-operators/merge-array.ts';
 export * from './trans-operators/concat.ts';
 export * from './trans-operators/flat-map.ts';
 export * from './trans-operators/switch-map.ts';

--- a/lib/src/observable.ts
+++ b/lib/src/observable.ts
@@ -78,14 +78,15 @@ export class Subject<T> implements Observable<T> {
     // Add the new subscriber to the list
     this._subscribers.push(newSubscriber);
 
-    // If there is a pending value emits this value to the new subscriber
-    if (this._lastValue !== undefined && run) {
-      newSubscriber.next?.(this._lastValue);
-    }
-
-    // If there is a pending error emits this error to the new subscriber
+    // If there is a pending error emits this error to the new subscriber and do not emit any values.
     if (this._currentError && newSubscriber.error) {
       newSubscriber.error(this._currentError);
+      return { unsubscribe };
+    }
+
+    // If there is pending value, no emitter and `run` is true: emits current value.
+    if (this._lastValue !== undefined && !this._emitter && run) {
+      newSubscriber.next?.(this._lastValue);
     }
 
     // If we have a onSubscribe function, call it

--- a/lib/src/trans-operators/map.ts
+++ b/lib/src/trans-operators/map.ts
@@ -9,8 +9,7 @@ import { Subject } from '../index.ts';
  */
 export const map =
   <T, U>(transform: (value: T) => U): Operator<T, U> => (source: Observable<T>): Observable<U> => {
-    const result$ = new Subject<U>();
-    result$.onSubscribe(() => {
+    const result$ = new Subject<U>(() => {
       source.subscribe({
         next: (value) => result$.emit(transform(value)),
         error: (err) => result$.error(err),

--- a/lib/src/trans-operators/merge-array.ts
+++ b/lib/src/trans-operators/merge-array.ts
@@ -3,22 +3,26 @@ import type { Observable, ObservableValues } from '../types.ts';
 
 /**
  * Merge an array of multiple observables into a single observable.
+ * The result observable will have the va
  * @param sources$ - the array of observables to merge
+ * @param setLastValue - if true use the last observable to set the value of the new merged observable.
  * @returns an observable that emits the values of all the observables
  */
 export const mergeArray = <
   Obs extends ReadonlyArray<Observable<unknown>>,
 >(
   sources$: Obs,
+  valueIdx: number = -1,
 ): Observable<ObservableValues<Obs>> => {
   const _values = sources$.map((o$) => o$.value);
-  const out$ = new Subject<ObservableValues<Obs>>();
-  sources$.forEach((obs$) =>
-    obs$.subscribe({
-      next: (v) => out$.emit(v as ObservableValues<Obs>),
-      error: (e) => out$.error(e),
-      complete: () => sources$.every((c) => c.isCompleted) && out$.complete(),
-    })
-  );
+  const out$ = new Subject<ObservableValues<Obs>>(() => {
+    sources$.forEach((obs$, idx) =>
+      obs$.subscribe({
+        next: (v) => out$.emit(v as ObservableValues<Obs>),
+        error: (e) => out$.error(e),
+        complete: () => sources$.every((c) => c.isCompleted) && out$.complete(),
+      }, valueIdx === idx) // Only emit the value of the valueIdx source
+    );
+  });
   return out$ as Observable<ObservableValues<Obs>>;
 };

--- a/lib/tests/operators/map.test.ts
+++ b/lib/tests/operators/map.test.ts
@@ -1,0 +1,16 @@
+/// <reference lib="deno.ns" />
+
+import { assertSpyCallArg, assertSpyCalls, spy } from 'jsr:@std/testing/mock';
+
+import { fromArray, map } from '../../src/index.ts';
+
+Deno.test('map() operator produces an observable that emits the mapped values', () => {
+  const obs$ = fromArray([1, 2, 3]);
+  const sub = spy();
+  const trg$ = map((x: number) => x + 1)(obs$);
+  trg$.subscribe(sub);
+  assertSpyCalls(sub, 3);
+  assertSpyCallArg(sub, 0, 0, 2);
+  assertSpyCallArg(sub, 1, 0, 3);
+  assertSpyCallArg(sub, 2, 0, 4);
+});

--- a/lib/tests/operators/merge-array.test.ts
+++ b/lib/tests/operators/merge-array.test.ts
@@ -11,12 +11,37 @@ Deno.test('mergeArray correctly emit when one of the merged observable emit', ()
   const obs1$ = new Subject(0);
   const obs2$ = new Subject('test');
   const obs3$ = new Subject({ test: 100 });
+  // Create a new observable merging the 3 sources and with undefined value
   const merged$ = mergeArray([obs1$, obs2$, obs3$]);
 
-  merged$.subscribe(spyFn, false);
+  merged$.subscribe(spyFn);
+
+  // We expect no call to the subscriber because the merged$.value is undefined.
+  assertSpyCalls(spyFn, 0);
+
   obs2$.emit('new test');
   assertSpyCalls(spyFn, 1);
   assertSpyCallArg(spyFn, 0, 0, 'new test');
+});
+
+Deno.test('mergeArray correctly emit when one of the merged observable emit', () => {
+  const spyFn = spy();
+
+  const obs1$ = new Subject(0);
+  const obs2$ = new Subject('test');
+  const obs3$ = new Subject({ test: 100 });
+  // Create a new observable merging the 3 sources and with value matching the last one.
+  const merged$ = mergeArray([obs1$, obs2$, obs3$], 2);
+
+  merged$.subscribe(spyFn);
+
+  // We expect to get an observable with the last source observable value.
+  assertSpyCalls(spyFn, 1);
+  assertSpyCallArg(spyFn, 0, 0, { test: 100 });
+
+  obs2$.emit('new test');
+  assertSpyCalls(spyFn, 2);
+  assertSpyCallArg(spyFn, 1, 0, 'new test');
 });
 
 Deno.test('mergeArray correctly completes when all source observable complete', () => {


### PR DESCRIPTION
## Summary

* Fixed the `map()` operator to use the emitter to subscribe to the source when on the first map subscriber.
* Fixed Subject to not emit or use emitter when being subscribed in an error state
* Improved mergeArray to allow to define which source observable (if any) will set the value of the merged one.
